### PR TITLE
Support Multipeer Connectivity as transport

### DIFF
--- a/DMXController.xcodeproj/project.pbxproj
+++ b/DMXController.xcodeproj/project.pbxproj
@@ -15,9 +15,22 @@
 		633332BF2D54517700A038F1 /* DMXController.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DMXController.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		63F4802D2D56356F00EE1F49 /* Exceptions for "DMXController" folder in "DMXController" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 633332BE2D54517700A038F1 /* DMXController */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		633332C12D54517700A038F1 /* DMXController */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				63F4802D2D56356F00EE1F49 /* Exceptions for "DMXController" folder in "DMXController" target */,
+			);
 			path = DMXController;
 			sourceTree = "<group>";
 		};
@@ -264,6 +277,8 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = DMXController/Info.plist;
+				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "for multipeer - with NSBonjourServices";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -303,6 +318,8 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = DMXController/Info.plist;
+				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "for multipeer - with NSBonjourServices";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;

--- a/DMXController/ContentView.swift
+++ b/DMXController/ContentView.swift
@@ -10,10 +10,11 @@ struct ContentView: View {
                     VStack {
                         HStack {
                             @Bindable var model = model
-                            Text("Universe \(universe0Origin + 1)")
+                            Text("Universe \(universe0Origin + 1)").fixedSize()
                             Picker("", selection: $model.sinkOrSources[universe0Origin]) {
-                                Text("Sink").tag(Model.SinkOrSource.sink)
-                                Text("Source").tag(Model.SinkOrSource.source)
+                                Text("Sink (\(model.sinkTransportDescription))").tag(Model.SinkOrSource.sink)
+                                Text("Source (\(model.sourceTransportDescription))").tag(Model.SinkOrSource.source)
+                                Text("Source (\(model.multipeerSourceTransportDescription))").tag(Model.SinkOrSource.sourceMultipeer)
                             }
                             .fixedSize()
                         }

--- a/DMXController/Info.plist
+++ b/DMXController/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSBonjourServices</key>
+	<array>
+		<string>_sacn._udp</string>
+		<string>_sacn._tcp</string>
+	</array>
+</dict>
+</plist>

--- a/Sources/DMX/sACN/Multipeer.swift
+++ b/Sources/DMX/sACN/Multipeer.swift
@@ -1,0 +1,86 @@
+import Foundation
+@preconcurrency import MultipeerConnectivity
+@preconcurrency import Combine
+
+public final class Multipeer: Sendable {
+    public static let defaultServiceName = "sacn" // add "_sacn._udp" to Info.plist
+    public let serviceType: String
+    public let peerID: MCPeerID
+    public let session: MCSession
+    public let advertiser: MCNearbyServiceAdvertiser
+    public let browser: MCNearbyServiceBrowser
+    public var receivedData: any Publisher<Data, Never> {sessionDelegate.receivedDataSubject.compactMap {$0}}
+
+    private let sessionDelegate: SessionDelegate = .init()
+    final class SessionDelegate: NSObject, MCSessionDelegate, Sendable {
+        let receivedDataSubject: CurrentValueSubject<Data?, Never> = .init(nil)
+
+        func session(_ session: MCSession, peer peerID: MCPeerID, didChange state: MCSessionState) {
+            NSLog("%@", "\(#function): state = \(state)")
+        }
+
+        func session(_ session: MCSession, didReceive data: Data, fromPeer peerID: MCPeerID) {
+            // NSLog("%@", "\(#function)")
+            receivedDataSubject.send(data)
+        }
+
+        func session(_ session: MCSession, didReceive stream: InputStream, withName streamName: String, fromPeer peerID: MCPeerID) {
+            NSLog("%@", "\(#function)")
+        }
+
+        func session(_ session: MCSession, didStartReceivingResourceWithName resourceName: String, fromPeer peerID: MCPeerID, with progress: Progress) {
+            NSLog("%@", "\(#function)")
+        }
+
+        func session(_ session: MCSession, didFinishReceivingResourceWithName resourceName: String, fromPeer peerID: MCPeerID, at localURL: URL?, withError error: (any Error)?) {
+            NSLog("%@", "\(#function)")
+        }
+    }
+
+    private let advertiserDelegate: AdvertiserDelegate
+    final class AdvertiserDelegate: NSObject, MCNearbyServiceAdvertiserDelegate, Sendable {
+        let session: MCSession
+        init(session: MCSession) {self.session = session}
+        func advertiser(_ advertiser: MCNearbyServiceAdvertiser, didReceiveInvitationFromPeer peerID: MCPeerID, withContext context: Data?, invitationHandler: @escaping (Bool, MCSession?) -> Void) {
+            NSLog("%@", "\(#function): fromPeer = \(peerID)")
+            invitationHandler(true, session) // TODO: more control, a away other than auto-connect
+        }
+    }
+
+    private let browserDelegate: BrowserDelegate
+    @MainActor final class BrowserDelegate: NSObject, @preconcurrency MCNearbyServiceBrowserDelegate {
+        let session: MCSession
+        init(session: MCSession) {self.session = session}
+        func browser(_ browser: MCNearbyServiceBrowser, foundPeer peerID: MCPeerID, withDiscoveryInfo info: [String : String]?) {
+            NSLog("%@", "\(#function): foundPeer = \(peerID)")
+            guard session.myPeerID.displayName < peerID.displayName else { return } // prioritize by same value for both peers
+            browser.invitePeer(peerID, to: session, withContext: nil, timeout: 30)  // TODO: more control, a away other than auto-connect
+        }
+        func browser(_ browser: MCNearbyServiceBrowser, lostPeer peerID: MCPeerID) {
+            NSLog("%@", "\(#function): lostPeer = \(peerID)")
+        }
+    }
+
+    @MainActor public init(serviceType: String = defaultServiceName, displayName: String = ProcessInfo().hostName + " " + ProcessInfo().processName + " " + String(ProcessInfo().processIdentifier)) {
+        self.serviceType = serviceType
+        peerID = .init(displayName: String(displayName.prefix(63)))
+        session = .init(peer: peerID, securityIdentity: nil, encryptionPreference: .required)
+        session.delegate = sessionDelegate
+        advertiser = .init(peer: peerID, discoveryInfo: nil, serviceType: serviceType)
+        advertiserDelegate = .init(session: session)
+        advertiser.delegate = advertiserDelegate
+        browser = .init(peer: peerID, serviceType: serviceType)
+        browserDelegate = .init(session: session)
+        browser.delegate = browserDelegate
+    }
+
+    public func start() {
+        advertiser.startAdvertisingPeer()
+        browser.startBrowsingForPeers()
+    }
+
+    public func stop() {
+        advertiser.stopAdvertisingPeer()
+        browser.stopBrowsingForPeers()
+    }
+}


### PR DESCRIPTION
Although sACN uses UDP multicast 239.255.universeHi.universeLo as its transport, it's useful to use another transport layer for real world devices in particular iOS/visionOS devices that requires an Apple authorized special entitlement file for sending multicast packet.

----

> Note: You can test your app using the iOS and iPadOS simulators without an active entitlement, but using multicast and broadcast networking on physical hardware requires the entitlement.
> [Request the com.apple.developer.networking.multicast entitlement](https://developer.apple.com/contact/request/networking-multicast)

-- How to use multicast networking in your app https://developer.apple.com/news/?id=0oi77447