### PR TITLE
Add Scheduler

### DIFF
--- a/DMXController.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DMXController.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,24 @@
+{
+  "originHash" : "70feaeee35be77d749130aa72694edddc2dc31a2c2ae55bff413d050f992765b",
+  "pins" : [
+    {
+      "identity" : "swift-async-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-async-algorithms",
+      "state" : {
+        "revision" : "6ae9a051f76b81cc668305ceed5b0e0a7fd93d20",
+        "version" : "1.0.1"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "671108c96644956dddcd89dd59c203dcdb36cec7",
+        "version" : "1.1.4"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,24 @@
+{
+  "originHash" : "cdb240c089effe14fbca1d4f82c9fd7f3c67932d0c3027e8dc769b9d9b532dcc",
+  "pins" : [
+    {
+      "identity" : "swift-async-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-async-algorithms",
+      "state" : {
+        "revision" : "6ae9a051f76b81cc668305ceed5b0e0a7fd93d20",
+        "version" : "1.0.1"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "671108c96644956dddcd89dd59c203dcdb36cec7",
+        "version" : "1.1.4"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Package.swift
+++ b/Package.swift
@@ -5,18 +5,23 @@ import PackageDescription
 
 let package = Package(
     name: "DMX",
-    platforms: [.macOS(.v14)],
+    platforms: [.macOS(.v15), .visionOS(.v2)],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(
             name: "DMX",
             targets: ["DMX"]),
     ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-async-algorithms", from: "1.0.0"),
+        ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
         // Targets can depend on other targets in this package and products from dependencies.
         .target(
-            name: "DMX"),
+            name: "DMX",
+            dependencies: [.product(name: "AsyncAlgorithms", package: "swift-async-algorithms")]
+        ),
         .testTarget(
             name: "DMXTests",
             dependencies: ["DMX"]

--- a/Sources/DMX/sACN/Resolver.swift
+++ b/Sources/DMX/sACN/Resolver.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+struct RawEventValue {
+    var universe: UInt16BE
+    var dmx: DMX? // nil to clear (it means app is no longer source for universe) for universe
+}
+typealias AggregatedEventValue = [UInt16BE: DMX]
+
+public protocol Resolver: Sendable {
+    @inlinable func resolve(into old: inout DMX, new: DMX)
+}
+extension Resolver {
+    func resolve(reduced: AggregatedEventValue?, value: RawEventValue) -> AggregatedEventValue {
+        guard let dmx = value.dmx else {
+            if var reduced {
+                reduced.removeValue(forKey: value.universe)
+                return reduced
+            }
+            return [:]
+        }
+        guard var reduced else { return [value.universe: dmx] }
+        if reduced[value.universe] != nil {
+            resolve(into: &reduced[value.universe]!, new: dmx)
+        } else {
+            reduced[value.universe] = value.dmx
+        }
+        return reduced
+    }
+}
+
+public enum Resolvers {
+    public static var newest: some Resolver {Resolvers.Newest()}
+    public struct Newest: Resolver {
+        @inlinable public func resolve(into old: inout DMX, new: DMX) {
+            old.value = new.value
+        }
+    }
+
+    public static var htp: some Resolver {Resolvers.HighestTakesPrecedence()}
+    public struct HighestTakesPrecedence: Resolver {
+        @inlinable public func resolve(into old: inout DMX, new: DMX) {
+            old.value = zip(old.value, new.value).map(max)
+        }
+    }
+}

--- a/Sources/DMX/sACN/SinkScheduler.swift
+++ b/Sources/DMX/sACN/SinkScheduler.swift
@@ -1,0 +1,34 @@
+import Foundation
+import AsyncAlgorithms
+
+final class SinkScheduler {
+    private var payloadStream: AsyncStream<Sink.Payload>
+    private var payloadStreamContinuation: AsyncStream<Sink.Payload>.Continuation?
+    var payloadsSequence: some AsyncSequence<[UInt16BE: Sink.Payload], Never> & Sendable {
+        let resolver = self.resolver
+        return payloadStream
+            ._throttle(for: interval, clock: .continuous) { reduced, payload in
+                guard var reduced else { return [payload.universe: payload] }
+                if reduced[payload.universe] != nil {
+                    resolver.resolve(into: &reduced[payload.universe]!.dmx, new: payload.dmx)
+                } else {
+                    reduced[payload.universe] = payload
+                }
+                return reduced
+            }
+    }
+
+    let interval: ContinuousClock.Instant.Duration
+    let resolver: any Resolver
+
+    init(interval: ContinuousClock.Instant.Duration, resolver: any Resolver) {
+        self.interval = interval
+        self.resolver = resolver
+        self.payloadStream = .init {_ in} // dummy for init
+        self.payloadStream = .init {payloadStreamContinuation = $0}
+    }
+
+    func receive(payload: Sink.Payload) {
+        payloadStreamContinuation?.yield(payload)
+    }
+}

--- a/Sources/DMX/sACN/SourceScheduler.swift
+++ b/Sources/DMX/sACN/SourceScheduler.swift
@@ -1,0 +1,70 @@
+import Foundation
+import AsyncAlgorithms
+
+/// NOTE:
+/// > 6.6.2 Null START Code Transmission Requirements in E1.31 Data Packets
+/// >
+/// > 2. Thereafter, a single keep-alive packet shall be transmitted at intervals of between 800mS and 1000mS.
+/// > Each keep-alive packet shall have identical content to the last Null START Code data packet sent with the
+/// > exception that the sequence number shall continue to increment normally.
+final class SourceScheduler: Sendable {
+    private let values: AsyncChannel<RawEventValue> = .init() // TODO: per-universe scheduling?
+    var aggregatedValues: some AsyncSequence<AggregatedEventValue, Never> {
+        values
+            .resolve(resolver: resolver) // TODO: actually not needed for source side. use at sink side
+            ._throttle(for: minInterval, clock: clock)
+            .replayOnIdle(for: maxInterval, clock: clock)
+    }
+    let clock: ContinuousClock = .continuous
+    let minInterval: ContinuousClock.Duration
+    let maxInterval: ContinuousClock.Duration
+    let resolver: any Resolver
+
+    init(minInterval: ContinuousClock.Duration = .milliseconds(25), maxInterval: ContinuousClock.Duration = .milliseconds(800), resolver: any Resolver = Resolvers.Newest()) {
+        self.minInterval = minInterval
+        self.maxInterval = maxInterval
+        self.resolver = resolver
+    }
+
+    func set(universe: UInt16BE, dmx: DMX?) async {
+        await values.send(.init(universe: universe, dmx: dmx))
+    }
+}
+
+extension AsyncSequence where Self: Sendable, Element == RawEventValue {
+    func resolve(resolver: any Resolver) -> some AsyncSequence<AggregatedEventValue, Failure> & Sendable {
+        nonisolated(unsafe) var aggregated: AggregatedEventValue?
+        return map {
+            let v = resolver.resolve(reduced: aggregated, value: $0)
+            aggregated = v
+            return v
+        }
+    }
+}
+
+extension AsyncSequence where Self: Sendable, Element: Sendable {
+    func replayOnIdle<C: Clock>(for interval: C.Instant.Duration, clock: C = .continuous) -> AsyncStream<Element> {
+        .init { c in
+            Task {
+                var timer: Task<Void, Error>?
+                defer {
+                    timer?.cancel()
+                    c.finish()
+                }
+
+                for try await value in self {
+                    c.yield(value)
+
+                    timer?.cancel()
+                    timer = Task {
+                        while true {
+                            try await Task.sleep(for: interval, clock: clock)
+                            try Task.checkCancellation()
+                            c.yield(value)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
sACN architecture uses constant network traffics that emits repeated DMX values even if the values are unchaged. Use scheduler to repeat values in appropriate intervals.